### PR TITLE
consuming kontrolluser and convert to user

### DIFF
--- a/src/main/java/no/fintlabs/user/KontrollUser.java
+++ b/src/main/java/no/fintlabs/user/KontrollUser.java
@@ -1,0 +1,23 @@
+package no.fintlabs.user;
+
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Slf4j
+public class KontrollUser {
+    private Long id;
+    private String resourceId;
+    private String firstName;
+    private String lastName;
+    private String userType;
+    private String userName;
+    private UUID identityProviderUserObjectId;
+    private String mainOrganisationUnitName;
+    private String mainOrganisationUnitId;
+}

--- a/src/main/java/no/fintlabs/user/User.java
+++ b/src/main/java/no/fintlabs/user/User.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 @Table(name="Users")
 @AllArgsConstructor
 @NoArgsConstructor(access=AccessLevel.PUBLIC, force=true)
+@Builder
 public class User {
     @Id
     private Long id;

--- a/src/main/java/no/fintlabs/user/UserConsumerConfiguration.java
+++ b/src/main/java/no/fintlabs/user/UserConsumerConfiguration.java
@@ -2,7 +2,6 @@ package no.fintlabs.user;
 
 import no.fintlabs.kafka.entity.EntityConsumerFactoryService;
 import no.fintlabs.kafka.entity.topic.EntityTopicNameParameters;
-import no.fintlabs.resource.Resource;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,13 +16,13 @@ public class UserConsumerConfiguration {
     ){
         EntityTopicNameParameters entityTopicNameParameters = EntityTopicNameParameters
                 .builder()
-                .resource("member")
+                .resource("kontrolluser")
                 .build();
 
         ConcurrentMessageListenerContainer container = entityConsumerFactoryService.createFactory(
-                        User.class,
-                        (ConsumerRecord<String,User> consumerRecord)
-                                -> userService.save(consumerRecord.value()))
+                        KontrollUser.class,
+                        (ConsumerRecord<String,KontrollUser> consumerRecord)
+                                -> userService.convertAndSaveAsUser(consumerRecord.value()))
                 .createContainer(entityTopicNameParameters);
 
         return container;

--- a/src/main/java/no/fintlabs/user/UserService.java
+++ b/src/main/java/no/fintlabs/user/UserService.java
@@ -1,7 +1,6 @@
 package no.fintlabs.user;
 
 import lombok.extern.slf4j.Slf4j;
-import no.fintlabs.resource.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,5 +19,20 @@ public class UserService {
     public Page<User> findBySearchCriteria(Specification<User> spec, Pageable page){
         Page<User> searchResult = userRepository.findAll(spec, page);
         return searchResult;
+    }
+
+    public User convertAndSaveAsUser(KontrollUser kontrollUser) {
+        User convertedUser = User.builder()
+                .id(kontrollUser.getId())
+                .identityProviderUserObjectId(kontrollUser.getIdentityProviderUserObjectId())
+                .firstName(kontrollUser.getFirstName())
+                .lastName(kontrollUser.getLastName())
+                .userType(kontrollUser.getUserType())
+                .organisationUnitId(kontrollUser.getMainOrganisationUnitId())
+                .organisationUnitName(kontrollUser.getMainOrganisationUnitName())
+                .build();
+
+
+        return save(convertedUser);
     }
 }


### PR DESCRIPTION
Leser inn kontrolluser fra kafka istedet for member. Konverterer disse til user som blir lagret via opprinnelig save(user) metode.
Testet lokalt. 